### PR TITLE
Feature/#2 slack 

### DIFF
--- a/com.spring.dozen.notification/build.gradle
+++ b/com.spring.dozen.notification/build.gradle
@@ -28,9 +28,14 @@ ext {
 }
 
 dependencies {
+	// slack
+	implementation 'com.slack.api:bolt:1.44.2'
+	implementation 'com.slack.api:bolt-servlet:1.44.2'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/com.spring.dozen.notification/http/Slack.http
+++ b/com.spring.dozen.notification/http/Slack.http
@@ -1,0 +1,10 @@
+### 슬랙 메시지
+POST localhost:19091/api/slack-messages
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJ1c2VyX2lkIjoxMCwicm9sZSI6Ik1BU1RFUiIsImlzcyI6ImF1dGgtc2VydmljZSIsImlhdCI6MTczNDMyNzAwNCwiZXhwIjoxNzM0MzMwNjA0fQ.Yx4pyeY_YjJ95GPsKU6ghuytiWnCzM27MY5UiSS0bUCLccpmCBrKewx9jSzhgNZ5SuphJZfqW2eXR0gvYydaBQ
+
+{
+  "messageContent": "테스트3",
+  "senderUserId": 1,
+  "receiverUserId": 2
+}

--- a/com.spring.dozen.notification/http/Slack.http
+++ b/com.spring.dozen.notification/http/Slack.http
@@ -1,10 +1,10 @@
 ### 슬랙 메시지
 POST localhost:19091/api/slack-messages
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJ1c2VyX2lkIjoxMCwicm9sZSI6Ik1BU1RFUiIsImlzcyI6ImF1dGgtc2VydmljZSIsImlhdCI6MTczNDMyNzAwNCwiZXhwIjoxNzM0MzMwNjA0fQ.Yx4pyeY_YjJ95GPsKU6ghuytiWnCzM27MY5UiSS0bUCLccpmCBrKewx9jSzhgNZ5SuphJZfqW2eXR0gvYydaBQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJ1c2VyX2lkIjoxMCwicm9sZSI6Ik1BU1RFUiIsImlzcyI6ImF1dGgtc2VydmljZSIsImlhdCI6MTczNDMzMTIzNiwiZXhwIjoxNzM0MzM0ODM2fQ.1TSjLQyMyQbSExhPF2pK09lCTxo938iuVABoAQpLSL97sgQW6p2ipzYsYEvszunfWWxfTm7Mqkj59TH8tfZytw
 
 {
-  "messageContent": "테스트3",
+  "messageContent": "테스트4",
   "senderUserId": 1,
   "receiverUserId": 2
 }

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/NotificationApplication.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/NotificationApplication.java
@@ -2,7 +2,9 @@ package com.spring.dozen.notification;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-//
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+@EnableFeignClients
 @SpringBootApplication
 public class NotificationApplication {
 

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/client/UserClient.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/client/UserClient.java
@@ -1,0 +1,10 @@
+package com.spring.dozen.notification.application.client;
+
+import com.spring.dozen.notification.application.client.dto.UserResponse;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface UserClient {
+    UserResponse getUsersForSlack(@RequestParam("senderId") Long senderId,
+                                  @RequestParam("receiverId") Long receiverId);
+
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/client/dto/UserResponse.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/client/dto/UserResponse.java
@@ -1,0 +1,9 @@
+package com.spring.dozen.notification.application.client.dto;
+
+public record UserResponse(
+        Long senderUserId,
+        String senderSlackId,
+        Long receiverUserId,
+        String receiverSlackId
+) {
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/dto/SlackMessageCreate.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/dto/SlackMessageCreate.java
@@ -1,0 +1,8 @@
+package com.spring.dozen.notification.application.dto;
+
+public record SlackMessageCreate(
+        String messageContent,
+        Long senderUserId,
+        Long receiverUserId
+) {
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/dto/SlackMessageCreatedEvent.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/dto/SlackMessageCreatedEvent.java
@@ -1,0 +1,10 @@
+package com.spring.dozen.notification.application.dto;
+
+public record SlackMessageCreatedEvent(
+        String messageContent,
+        Long senderUserId,
+        String senderSlackId,
+        Long receiverUserId,
+        String receiverSlackId
+) {
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/dto/SlackMessageResponse.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/dto/SlackMessageResponse.java
@@ -1,0 +1,29 @@
+package com.spring.dozen.notification.application.dto;
+
+import com.spring.dozen.notification.application.client.dto.UserResponse;
+import com.spring.dozen.notification.domain.entity.SlackMessage;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SlackMessageResponse(
+        UUID slackMessageId,
+        String messageContent,
+        Long senderUserId,
+        String senderSlackId,
+        Long receiverUserId,
+        String receiverSlackId,
+        LocalDateTime sentAt
+) {
+    public static SlackMessageResponse from(SlackMessage slackMessage, UserResponse userResponse) {
+        return new SlackMessageResponse(
+                slackMessage.getId(),
+                slackMessage.getMessageContent(),
+                slackMessage.getSenderUserId(),
+                userResponse.senderSlackId(),
+                slackMessage.getReceiverUserId(),
+                userResponse.receiverSlackId(),
+                slackMessage.getSentAt()
+        );
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/exception/ExceptionResponse.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/exception/ExceptionResponse.java
@@ -1,0 +1,11 @@
+package com.spring.dozen.notification.application.exception;
+
+public record ExceptionResponse(
+        String message
+) {
+    public String toWrite() {
+        return "{" +
+                "\"message\":" + "\"" + message + "\"" +
+                "}";
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/exception/GlobalExceptionHandler.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/exception/GlobalExceptionHandler.java
@@ -1,0 +1,65 @@
+package com.spring.dozen.notification.application.exception;
+
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.Arrays;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private final String ERROR_LOG = "[ERROR] %s %s";
+
+    @ExceptionHandler(NotificationException.class)
+    public ResponseEntity<ExceptionResponse> applicationException(final NotificationException e){
+        log.error(String.format(ERROR_LOG, e.getHttpStatus(), e.getMessage()));
+        return ResponseEntity.status(e.getHttpStatus()).body(new ExceptionResponse(e.getMessage()));
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ExceptionResponse handleNoResourceFoundException(NoResourceFoundException e) {
+        log.error(String.format(ERROR_LOG, e.getMessage(), e.getClass().getName()));
+        return new ExceptionResponse("지원하지 않는 경로입니다.");
+    }
+
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ExceptionResponse httpReqMethodNotSupportException(final HttpRequestMethodNotSupportedException e){
+        log.error(String.format(ERROR_LOG, e.getMessage(), Arrays.toString(e.getSupportedMethods())));
+        return new ExceptionResponse("지원하지 않는 요청 방법입니다.");
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ExceptionResponse missingServletRequestParameter(final MissingServletRequestParameterException e) {
+        log.error(String.format(ERROR_LOG, e.getParameterName(), e.getMessage()));
+        return new ExceptionResponse("필요한 파라미터가 입력되지 않았습니다.");
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ExceptionResponse methodArgumentNotValidException(final MethodArgumentNotValidException e){
+        log.error(String.format(ERROR_LOG, e.getParameter(), e.getStatusCode()));
+        return new ExceptionResponse(e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+    }
+
+    @ExceptionHandler(FeignException.class)
+    public ExceptionResponse handleFeignException(final FeignException e) {
+        log.error(String.format(ERROR_LOG, "FeignClient Error", e.getMessage()));
+        HttpStatus status = HttpStatus.valueOf(e.status());
+        log.error("handleFeignException.status: {}", status);
+        log.error("error:", e);
+        return new ExceptionResponse("발신자 또는 수신자 정보가 존재하지 않습니다.");
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/exception/NotificationErrorCode.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/exception/NotificationErrorCode.java
@@ -1,0 +1,26 @@
+package com.spring.dozen.notification.application.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode {
+
+    // UNAUTHORIZED & FORBIDDEN
+    FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 존재하지 않습니다."),
+
+    // Notification
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 메시지 정보가 존재하지 않습니다."),
+    SLACK_MESSAGE_SEND_FAILED(HttpStatus.NOT_FOUND,"슬랙 메시지 전송에 실패했습니다."),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "발신자 또는 수신자 정보가 존재하지 않습니다."),
+
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/exception/NotificationException.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/exception/NotificationException.java
@@ -1,0 +1,15 @@
+package com.spring.dozen.notification.application.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class NotificationException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public NotificationException(NotificationErrorCode authErrorCode) {
+        this.httpStatus = authErrorCode.getHttpStatus();
+        this.message = authErrorCode.getMessage();
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/service/SlackMessageService.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/service/SlackMessageService.java
@@ -1,0 +1,50 @@
+package com.spring.dozen.notification.application.service;
+
+import com.spring.dozen.notification.application.client.UserClient;
+import com.spring.dozen.notification.application.client.dto.UserResponse;
+import com.spring.dozen.notification.application.dto.SlackMessageCreate;
+import com.spring.dozen.notification.application.dto.SlackMessageCreatedEvent;
+import com.spring.dozen.notification.application.dto.SlackMessageResponse;
+import com.spring.dozen.notification.application.exception.NotificationErrorCode;
+import com.spring.dozen.notification.application.exception.NotificationException;
+import com.spring.dozen.notification.domain.entity.SlackMessage;
+import com.spring.dozen.notification.domain.repository.SlackMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class SlackMessageService {
+    private final SlackMessageRepository slackMessageRepository;
+    private final UserClient userClient;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public SlackMessageResponse send(SlackMessageCreate createRequest) {
+        log.info("send.SlackMessageCreate {}", createRequest);
+        UserResponse userResponse
+                = userClient.getUsersForSlack(createRequest.senderUserId(), createRequest.receiverUserId());
+        log.info("send.UserResponse: {}", userResponse);
+        if (userResponse.senderSlackId().isEmpty() || userResponse.receiverSlackId().isEmpty()) {
+            throw new NotificationException(NotificationErrorCode.USER_NOT_FOUND);
+        }
+        SlackMessage slackMessage = SlackMessage.create(createRequest.messageContent(),
+                userResponse.senderUserId(),
+                userResponse.receiverUserId());
+
+        // 이벤트 발행
+        eventPublisher.publishEvent(new SlackMessageCreatedEvent(
+                createRequest.messageContent(),
+                userResponse.senderUserId(),
+                userResponse.senderSlackId(),
+                userResponse.receiverUserId(),
+                userResponse.receiverSlackId()
+        ));
+
+        return SlackMessageResponse.from(slackMessageRepository.save(slackMessage), userResponse);
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/service/SlackMessageService.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/application/service/SlackMessageService.java
@@ -36,6 +36,8 @@ public class SlackMessageService {
                 userResponse.senderUserId(),
                 userResponse.receiverUserId());
 
+        slackMessageRepository.save(slackMessage);
+
         // 이벤트 발행
         eventPublisher.publishEvent(new SlackMessageCreatedEvent(
                 createRequest.messageContent(),
@@ -45,6 +47,6 @@ public class SlackMessageService {
                 userResponse.receiverSlackId()
         ));
 
-        return SlackMessageResponse.from(slackMessageRepository.save(slackMessage), userResponse);
+        return SlackMessageResponse.from(slackMessage, userResponse);
     }
 }

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/domain/entity/BaseEntity.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/domain/entity/BaseEntity.java
@@ -1,0 +1,59 @@
+package com.spring.dozen.notification.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Column(name = "is_deleted") // 삭제 여부
+    @ColumnDefault("false")
+    private Boolean isDeleted;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", length = 20)
+    private String createdBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by", length = 20)
+    private String updatedBy;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by", length = 20)
+    private String deletedBy;
+
+    /**
+     * 도메인 규칙 Long userId를 입력받으면 String 으로 변환해서 deletedBy에 저장
+     * */
+    public void deleteBase(Long userId) {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = String.valueOf(userId);
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/domain/entity/SlackMessage.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/domain/entity/SlackMessage.java
@@ -1,0 +1,46 @@
+package com.spring.dozen.notification.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "p_slack_message")
+public class SlackMessage extends BaseEntity{
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(name = "slack_message_id", nullable = false, columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Column(columnDefinition = "TEXT")
+    private String messageContent;
+
+    @Column(name = "sender_user_id", nullable = false)
+    private Long senderUserId;
+
+    @Column(name = "receiver_user_id", nullable = false)
+    private Long receiverUserId;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    public static SlackMessage create(String messageContent, Long senderUserId, Long receiverUserId) {
+        return SlackMessage.builder()
+                .messageContent(messageContent)
+                .senderUserId(senderUserId)
+                .receiverUserId(receiverUserId)
+                .sentAt(LocalDateTime.now())
+                .build();
+    }
+
+
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/domain/repository/SlackMessageRepository.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/domain/repository/SlackMessageRepository.java
@@ -1,0 +1,14 @@
+package com.spring.dozen.notification.domain.repository;
+
+import com.spring.dozen.notification.domain.entity.SlackMessage;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface SlackMessageRepository {
+    Optional<SlackMessage> findById(UUID id);
+
+    SlackMessage save(SlackMessage slackMessage);
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/client/UserClientImpl.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/client/UserClientImpl.java
@@ -1,0 +1,15 @@
+package com.spring.dozen.notification.infra.client;
+
+import com.spring.dozen.notification.application.client.UserClient;
+import com.spring.dozen.notification.application.client.dto.UserResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "auth-service")
+public interface UserClientImpl extends UserClient {
+
+    @GetMapping("/api/users/slack-ids")
+    UserResponse getUsersForSlack(@RequestParam("senderId") Long senderId,
+                                  @RequestParam("receiverId") Long receiverId);
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/config/AsyncConfig.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.spring.dozen.notification.infra.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(25);
+        executor.setThreadNamePrefix("Async-");
+        executor.initialize();
+        return executor;
+    }
+}
+

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/config/jpa/AuditorAwareImpl.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/config/jpa/AuditorAwareImpl.java
@@ -1,0 +1,21 @@
+package com.spring.dozen.notification.infra.config.jpa;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Optional;
+
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        // RequestContext에서 X-User-Id 헤더를 추출
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes != null) {
+            String userId = attributes.getRequest().getHeader("X-User-Id");
+            return Optional.ofNullable(userId);
+        }
+        return Optional.empty();
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/config/jpa/JpaAuditingConfig.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/config/jpa/JpaAuditingConfig.java
@@ -1,0 +1,16 @@
+package com.spring.dozen.notification.infra.config.jpa;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/config/slack/SlackConfig.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/config/slack/SlackConfig.java
@@ -1,0 +1,25 @@
+package com.spring.dozen.notification.infra.config.slack;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SlackConfig {
+
+    @Value("${slack.bot.token}")
+    private String slackBotToken;
+
+    @Bean
+    public Slack slack() {
+        return Slack.getInstance();
+    }
+
+    @Bean
+    public MethodsClient slackClient(Slack slack) {
+        return slack.methods(slackBotToken);
+    }
+}
+

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/event/SlackMessageSendListener.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/event/SlackMessageSendListener.java
@@ -1,0 +1,37 @@
+package com.spring.dozen.notification.infra.event;
+
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.spring.dozen.notification.application.dto.SlackMessageCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Async
+@Component
+public class SlackMessageSendListener {
+    private final MethodsClient slackClient;
+
+    @EventListener
+    public void handleSlackMessageSend(SlackMessageCreatedEvent event) {
+        try {
+            log.info("handleSlackMessageSend.SlackMessageCreatedEvent: {}", event);
+            ChatPostMessageResponse response = slackClient.chatPostMessage(req -> req
+                    .channel(event.receiverSlackId())
+                    .text(event.messageContent())
+                    .asUser(true));
+
+            if (!response.isOk()) {
+                log.error("Failed to send Slack message: {}", response.getError());
+                // 재시도 로직 구현 가능
+            }
+        } catch (Exception e) {
+            log.error("Error sending Slack message", e);
+            // 재시도 로직 구현 가능
+        }
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/event/SlackMessageSendListener.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/event/SlackMessageSendListener.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @RequiredArgsConstructor
-@Async
 @Component
 public class SlackMessageSendListener {
     private final MethodsClient slackClient;
 
-    @EventListener
+    @Async
+    @EventListener(SlackMessageCreatedEvent.class)
     public void handleSlackMessageSend(SlackMessageCreatedEvent event) {
         try {
             log.info("handleSlackMessageSend.SlackMessageCreatedEvent: {}", event);

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/repository/SlackMessageRepositoryImpl.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/infra/repository/SlackMessageRepositoryImpl.java
@@ -1,0 +1,11 @@
+package com.spring.dozen.notification.infra.repository;
+
+import com.spring.dozen.notification.domain.entity.SlackMessage;
+import com.spring.dozen.notification.domain.repository.SlackMessageRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SlackMessageRepositoryImpl
+        extends JpaRepository<SlackMessage, UUID>, SlackMessageRepository{
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/presentation/controller/SlackMessageController.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/presentation/controller/SlackMessageController.java
@@ -1,0 +1,26 @@
+package com.spring.dozen.notification.presentation.controller;
+
+import com.spring.dozen.notification.application.dto.SlackMessageResponse;
+import com.spring.dozen.notification.application.service.SlackMessageService;
+import com.spring.dozen.notification.presentation.dto.ApiResponse;
+import com.spring.dozen.notification.presentation.dto.SlackMessageCreateRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/slack-messages")
+@RestController
+public class SlackMessageController {
+    private final SlackMessageService slackMessageService;
+
+    @PostMapping
+    public ApiResponse<SlackMessageResponse> send(@RequestBody SlackMessageCreateRequest request) {
+        log.info("Sending Slack message: {}", request);
+        return ApiResponse.process(slackMessageService.send(request.toServiceDto()));
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/presentation/dto/ApiResponse.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/presentation/dto/ApiResponse.java
@@ -1,0 +1,27 @@
+package com.spring.dozen.notification.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * 공통 DTO
+ * */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T> (
+        String message,
+        T data
+) {
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("API 요청에 성공했습니다", data);
+    }
+
+    public static ApiResponse<Void> success() {
+        return new ApiResponse<>("API 요청에 성공했습니다", null);
+    }
+
+    /**
+     * 사용자에게 처리중이라고 알리기 위한 메서드
+     * */
+    public static <T> ApiResponse<T> process(T data) {
+        return new ApiResponse<>("지금 처리 중입니다.", data);
+    }
+}

--- a/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/presentation/dto/SlackMessageCreateRequest.java
+++ b/com.spring.dozen.notification/src/main/java/com/spring/dozen/notification/presentation/dto/SlackMessageCreateRequest.java
@@ -1,0 +1,14 @@
+package com.spring.dozen.notification.presentation.dto;
+
+import com.spring.dozen.notification.application.dto.SlackMessageCreate;
+
+public record SlackMessageCreateRequest(
+        String messageContent,
+        Long senderUserId,
+        Long receiverUserId
+) {
+
+    public SlackMessageCreate toServiceDto() {
+        return new SlackMessageCreate(messageContent, senderUserId, receiverUserId);
+    }
+}

--- a/com.spring.dozen.notification/src/main/resources/application.yml
+++ b/com.spring.dozen.notification/src/main/resources/application.yml
@@ -1,0 +1,30 @@
+server:
+  port: 19097
+
+spring:
+  application:
+    name: notification-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3311/notification_db
+    username: root
+    password: password
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+    show-sql: true
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/
+
+slack:
+  bot:
+    token: ${SLACK_BOT_TOKEN}
+  signing:
+    secret: ${SLACK_SIGNING_SECRET}

--- a/com.spring.dozen.notification/src/test/java/com/spring/dozen/notification/application/service/SlackMessageServiceTest.java
+++ b/com.spring.dozen.notification/src/test/java/com/spring/dozen/notification/application/service/SlackMessageServiceTest.java
@@ -1,0 +1,124 @@
+package com.spring.dozen.notification.application.service;
+
+import com.spring.dozen.notification.application.client.UserClient;
+import com.spring.dozen.notification.application.client.dto.UserResponse;
+import com.spring.dozen.notification.application.dto.SlackMessageCreate;
+import com.spring.dozen.notification.application.dto.SlackMessageResponse;
+import com.spring.dozen.notification.application.exception.NotificationException;
+import com.spring.dozen.notification.domain.repository.SlackMessageRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+class SlackMessageServiceTest {
+
+    @Autowired
+    private SlackMessageService slackMessageService;
+
+    @Autowired
+    private SlackMessageRepository slackMessageRepository;
+
+    @MockBean
+    private UserClient userClient;
+
+    @DisplayName("슬랙 메시지 생성 - 성공")
+    @Test
+    void send_WithValidRequest_ShouldCreateSlackMessage() {
+        // given
+        String messageContent = "test message";
+        Long senderUserId = 1L;
+        Long receiverUserId = 2L;
+        String senderSlackId = "userSlack001";
+        String receiverSlackId = "userSlack002";
+
+        SlackMessageCreate createRequest = new SlackMessageCreate(messageContent, senderUserId, receiverUserId);
+
+        // Mock UserClient response
+        given(userClient.getUsersForSlack(senderUserId, receiverUserId))
+                .willReturn(new UserResponse(senderUserId, senderSlackId, receiverUserId, receiverSlackId));
+
+        // when
+        SlackMessageResponse response = slackMessageService.send(createRequest);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.messageContent()).isEqualTo(messageContent);
+        assertThat(response.senderUserId()).isEqualTo(senderUserId);
+        assertThat(response.receiverUserId()).isEqualTo(receiverUserId);
+        assertThat(response.senderSlackId()).isEqualTo(senderSlackId);
+        assertThat(response.receiverSlackId()).isEqualTo(receiverSlackId);
+    }
+
+    @DisplayName("슬랙 메시지 생성 - 수신자 정보가 없으면 예외 발생한다.")
+    @Test
+    void send_Without_Receiver_ShouldThrowNotificationException() {
+        // given
+        String messageContent = "test message";
+        Long senderUserId = 1L;
+        Long receiverUserId = 2L;
+        String senderSlackId = "userSlack001";
+
+        SlackMessageCreate createRequest = new SlackMessageCreate(messageContent, senderUserId, receiverUserId);
+
+        // Mock UserClient response without receiver slack id
+        given(userClient.getUsersForSlack(senderUserId, receiverUserId))
+                .willReturn(new UserResponse(senderUserId, senderSlackId, receiverUserId, ""));
+
+        // when & then
+        assertThatThrownBy(() -> slackMessageService.send(createRequest))
+                .isInstanceOf(NotificationException.class)
+                .hasMessage("발신자 또는 수신자 정보가 존재하지 않습니다.");
+    }
+
+    @DisplayName("슬랙 메시지 생성 - 발신자 정보가 없으면 예외 발생한다.")
+    @Test
+    void send_Without_Sender_ShouldThrowNotificationException() {
+        // given
+        String messageContent = "test message";
+        Long senderUserId = 1L;
+        Long receiverUserId = 2L;
+        String receiverSlackId = "userSlack002";
+
+        SlackMessageCreate createRequest = new SlackMessageCreate(messageContent, senderUserId, receiverUserId);
+
+        // Mock UserClient response without sender slack id
+        given(userClient.getUsersForSlack(senderUserId, receiverUserId))
+                .willReturn(new UserResponse(senderUserId, "", receiverUserId, receiverSlackId));
+
+        // when & then
+        assertThatThrownBy(() -> slackMessageService.send(createRequest))
+                .isInstanceOf(NotificationException.class)
+                .hasMessage("발신자 또는 수신자 정보가 존재하지 않습니다.");
+    }
+
+    @DisplayName("슬랙 메시지 생성 - 발신자, 수신자 정보가 모두 없으면 예외 발생한다.")
+    @Test
+    void send_Without_Both_Side_ShouldThrowNotificationException() {
+        // given
+        String messageContent = "test message";
+        Long senderUserId = 1L;
+        Long receiverUserId = 2L;
+
+        SlackMessageCreate createRequest = new SlackMessageCreate(messageContent, senderUserId, receiverUserId);
+
+        // Mock UserClient response with empty slack ids
+        given(userClient.getUsersForSlack(senderUserId, receiverUserId))
+                .willReturn(new UserResponse(senderUserId, "", receiverUserId, ""));
+
+        // when & then
+        assertThatThrownBy(() -> slackMessageService.send(createRequest))
+                .isInstanceOf(NotificationException.class)
+                .hasMessage("발신자 또는 수신자 정보가 존재하지 않습니다.");
+    }
+}

--- a/com.spring.dozen.notification/src/test/resources/application-test.yml
+++ b/com.spring.dozen.notification/src/test/resources/application-test.yml
@@ -28,6 +28,6 @@ sql:
 
 slack:
   bot:
-    token: ${SLACK_BOT_TOKEN}
+    token: testtoken
   signing:
-    secret: ${SLACK_SIGNING_SECRET}
+    secret: testsigningsecret

--- a/com.spring.dozen.notification/src/test/resources/application-test.yml
+++ b/com.spring.dozen.notification/src/test/resources/application-test.yml
@@ -25,3 +25,9 @@ spring:
 sql:
   init:
     mode: never
+
+slack:
+  bot:
+    token: ${SLACK_BOT_TOKEN}
+  signing:
+    secret: ${SLACK_SIGNING_SECRET}


### PR DESCRIPTION
## **🔗 Related Issues**
> 예) 관련이슈 #번호
#2 

## **📋 Description**
> 이 PR에서 해결한 문제 또는 추가된 기능을 간략히 설명
- 슬랙 메시지 생성 기능을 구현했습니다.
- Auth-service를 호출하기 때문에 FeignException 예외 처리를 GlobalExceptionHandler에 추가했습니다.
- Auth-service 호출, 슬랙 메시지 송신, 데이터베이스 저장하는 작업이 시간이 오래 걸릴 것으로 판단해 
- EventListener를 활용해서 Auth-service 호출만 동기적으로 수행하고 나머지는 비동기로 수행하려고 했습니다.
- 데이터베이스 저장이 비동기로 수행되다보니 slackMessageId가 null이 반환되어 버려서 슬랙 메시지 송신만 비동기로 호출되도록 했습니다. 
- 기존: slackMessageId가 null
![슬랙메시지실제전송_이벤트리스너분리](https://github.com/user-attachments/assets/4f3fe19a-0271-4c2f-9d6a-300c4c3c51a7)

- 수정본
![슬랙메시지실제전송_이벤트리스너2](https://github.com/user-attachments/assets/080b02b5-834e-4b71-81f3-d69bb8b65129)


## **👀 Review Points**
> 리뷰어가 특별히 봐주었으면 하는 부분
- 슬랙 메시지 전송은 응답 후에 비동기로 수행되다보니 api 응답으로 "지금 처리중입니다"를 출력하도록 했습니다. 
- application.yml 에 slack 토큰을 직접 넣어줬더니 repo protection rule에 막혀서 새로운 브랜치를 만들고 복붙하다가 시간이 많이 소요되었네요 ㅠㅠ
